### PR TITLE
Use 'official' version of mmd.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "mmd": "git://github.com/mgnt/node-mmd.git",
+    "mmd": "~4.7.1",
     "debug": "~0.7.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Switched to using v 4.7.1 of mmd instead of branched version.
